### PR TITLE
Issue #23 Filling the Cache from the Validators

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1859,6 +1859,7 @@ dependencies = [
  "slog-term",
  "tokio",
  "toml",
+ "url",
  "wiremock",
 ]
 
@@ -2080,6 +2081,7 @@ dependencies = [
  "idna",
  "matches",
  "percent-encoding",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,16 +11,17 @@ futures = { version = "0.3" }
 # Server
 tokio = { version = "0.2", features = ["macros", "rt-threaded", "sync"] }
 hyper = { version = "0.13", features = ["stream"] }
-http = "0.2.0"
+http = "0.2"
 
 reqwest = { version = "0.10", features = ["json"] }
 
-serde = { version = "^1.0", features = ['derive'] }
+serde = { version = "^1.0", features = ["derive"] }
 serde_json = "^1.0"
 
 # CLI
-clap = "2.33.0"
+clap = "2.33"
 toml = "0.5"
+url = { version = "2.1", features = ["serde"]}
 
 # Logging
 slog = { version = "2.5" }
@@ -30,4 +31,4 @@ slog-async = "2.5"
 lazy_static = "1.4"
 
 [dev-dependencies]
-wiremock = "0.2.0"
+wiremock = "0.2"

--- a/config/dev.toml
+++ b/config/dev.toml
@@ -1,7 +1,7 @@
 # The list of Validators' Urls for fetching the Campaigns from
 validators = ["http://localhost:8005/", "http://localhost:8006/"]
 
-# is seconds - 4 minutes
+# in seconds - 4 minutes
 recency = 240
 fetch_campaigns_every = 60
 update_campaigns_every = 20

--- a/config/dev.toml
+++ b/config/dev.toml
@@ -1,11 +1,19 @@
+# The list of Validators' Urls for fetching the Campaigns from
+validators = ["http://localhost:8005/", "http://localhost:8006/"]
+
+# is seconds - 4 minutes
+recency = 240
+fetch_campaigns_every = 60
+update_campaigns_every = 20
+
+[limits]
 # if left out or commented out it won't be applied.
 # 100 DAI/TST
 limited_identity_earnings_limit = '100000000000000000000'
 
-# 4 minutes
-recency = 240
-fetch_campaigns_every = 60
-update_campaigns_every = 20
+# The maximum number of campaigns a publisher can earn from
+# This will limit the returned Campaigns to the set number
+maximum_publisher_earning_campaigns = 5
 
 [timeouts]
 cache_update_campaign_statuses = 10

--- a/config/prod.toml
+++ b/config/prod.toml
@@ -1,7 +1,7 @@
 # The list of Validators' Urls for fetching the Campaigns from
 validators = ["https://jerry.adex.network/", "https://tom.adex.network/"]
 
-# is seconds - 4 minutes
+# in seconds - 4 minutes
 recency = 240
 fetch_campaigns_every = 240
 update_campaigns_every = 50

--- a/config/prod.toml
+++ b/config/prod.toml
@@ -1,11 +1,19 @@
+# The list of Validators' Urls for fetching the Campaigns from
+validators = ["https://jerry.adex.network/", "https://tom.adex.network/"]
+
+# is seconds - 4 minutes
+recency = 240
+fetch_campaigns_every = 240
+update_campaigns_every = 50
+
+[limits]
 # if left out or commented out it won't be applied.
 # 100 DAI/TST
 limited_identity_earnings_limit = '100000000000000000000'
 
-# 4 minutes
-recency = 240
-fetch_campaigns_every = 240
-update_campaigns_every = 50
+# The maximum number of campaigns a publisher can earn from
+# This will limit the returned Campaigns to the set number
+maximum_publisher_earning_campaigns = 50
 
 [timeouts]
 cache_update_campaign_statuses = 40

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -30,11 +30,6 @@ pub struct Cache {
     sentry: SentryApi,
 }
 
-// pub enum Action {
-//     Update,
-//     Finalize,
-// }
-
 #[derive(Debug)]
 pub struct Campaign {
     channel: Channel,
@@ -102,6 +97,7 @@ impl Cache {
 
         self.update(ActiveAction::New(active), finalized).await
     }
+
     /// Updates the full Cache with the new values:
     ///
     /// 1. Updates Active cache:
@@ -118,12 +114,10 @@ impl Cache {
         {
             match &new_active {
                 ActiveAction::New(new_active) => {
-                    // let ids = debug_iter(new_active.keys());
                     info!(&self.logger, "Adding New {} Active Campaigns", new_active.len(); "ChannelIds" => format_args!("{:?}", new_active.keys()));
                 }
 
                 ActiveAction::Update(update_active) => {
-                    // let ids = debug_iter(update_active.keys());
                     info!(&self.logger, "Updating {} Active Campaigns", update_active.len(); "ChannelIds" => format_args!("{:?}", update_active.keys()));
                 }
             }
@@ -134,7 +128,6 @@ impl Cache {
                 ActiveAction::New(new_active) => active.extend(new_active),
                 ActiveAction::Update(update_active) => {
                     for (id, (new_status, new_balances)) in update_active {
-                        // TODO: Check if this actually mutates the Campaign
                         active.get_mut(&id).and_then(|campaign| {
                             campaign.status = new_status;
                             campaign.balances = new_balances;
@@ -218,7 +211,7 @@ async fn collect_all_campaigns(
             // @TODO: Issue #23 Check ChannelId and the received Channel hash
             info!(
                 logger,
-                "Skipping Channel ({:?}) because it's already fetched from another Validator",
+                "Skipping Campaign ({:?}) because it's already fetched from another Validator",
                 &channel.id
             )
         } else {
@@ -274,8 +267,13 @@ async fn get_all_channels<'a>(
 #[cfg(test)]
 mod test {
     use super::*;
+    
+    // TODO: Remove
+    #[allow(unused_imports)]
     use primitives::util::tests::prep_db::{DUMMY_CHANNEL, IDS};
 
+    // TODO: Remove
+    #[allow(dead_code)]
     fn setup_cache(
         active: HashMap<ChannelId, Campaign>,
         finalized: HashSet<ChannelId>,
@@ -287,7 +285,6 @@ mod test {
         let drain = slog_async::Async::new(drain).build().fuse();
         let logger = slog::Logger::root(drain, slog::o!());
 
-        let market = MarketApi::new("http://localhost:8005".into(), logger.clone())?;
         let sentry = SentryApi::new(std::time::Duration::from_secs(60))?;
 
         let cache = Cache {

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -277,10 +277,11 @@ mod test {
     use chrono::{Duration, Utc};
     use primitives::{
         sentry::{
-            ChannelListResponse, LastApproved, LastApprovedResponse, ValidatorMessage,
-            ValidatorMessageResponse, NewStateValidatorMessage,
+            ChannelListResponse, LastApproved, LastApprovedResponse, NewStateValidatorMessage,
+            ValidatorMessage, ValidatorMessageResponse,
         },
-        util::tests::prep_db::{DUMMY_CHANNEL, DUMMY_VALIDATOR_FOLLOWER, DUMMY_VALIDATOR_LEADER}, validator::{NewState, MessageTypes},
+        util::tests::prep_db::{DUMMY_CHANNEL, DUMMY_VALIDATOR_FOLLOWER, DUMMY_VALIDATOR_LEADER},
+        validator::{MessageTypes, NewState},
     };
     use wiremock::{
         matchers::{method, path},
@@ -451,7 +452,10 @@ mod test {
             balances: Default::default(),
         };
 
-        let expected_balances: BalancesMap = vec![(leader_id, 10.into()), (follower_id, 100.into())].into_iter().collect();
+        let expected_balances: BalancesMap =
+            vec![(leader_id, 10.into()), (follower_id, 100.into())]
+                .into_iter()
+                .collect();
         let expected_status = Status::Initializing;
 
         let leader_new_state = NewStateValidatorMessage {

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,8 +1,10 @@
 use lazy_static::lazy_static;
 use primitives::BigNum;
-use serde::{Deserialize, Deserializer, Serialize};
+use serde::{Deserialize, Deserializer};
+use std::collections::HashSet;
 use std::fmt;
 use std::time::Duration;
+use url::Url;
 
 lazy_static! {
     static ref DEVELOPMENT: Config = {
@@ -15,38 +17,45 @@ lazy_static! {
     };
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Deserialize, Debug, Clone)]
 pub struct Config {
-    #[serde(default)]
-    pub limited_identity_earnings_limit: Option<BigNum>,
+    pub validators: HashSet<Url>,
     #[serde(deserialize_with = "seconds_to_std_duration")]
-    /// (Now - Recency) determins if a Datetime is recent or not
+    /// (Now - Recency) determines if a DateTime is recent or not
     pub recency: Duration,
     #[serde(deserialize_with = "seconds_to_std_duration")]
     pub fetch_campaigns_every: Duration,
     #[serde(deserialize_with = "seconds_to_std_duration")]
     pub update_campaigns_every: Duration,
+    pub limits: Limits,
     pub timeouts: Timeouts,
 }
 
 impl Config {
-    pub fn new(config_path: Option<&str>, environment: &str) -> Result<Config, ConfigError> {
+    pub fn new(config_path: Option<&str>, environment: &str) -> Result<Config, Error> {
         if let Some(path) = config_path {
-            let content = std::fs::read_to_string(path).map_err(ConfigError::Io)?;
-            return toml::from_str(&content).map_err(ConfigError::Toml);
+            let content = std::fs::read_to_string(path).map_err(Error::Io)?;
+            return toml::from_str(&content).map_err(Error::Toml);
         }
 
         match environment {
             "development" => Ok(DEVELOPMENT.clone()),
             "production" => Ok(PRODUCTION.clone()),
-            env => Err(ConfigError::Environment {
+            env => Err(Error::Environment {
                 actual: env.to_string(),
             }),
         }
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Deserialize, Debug, Clone)]
+pub struct Limits {
+    #[serde(default)]
+    pub limited_identity_earnings_limit: Option<BigNum>,
+    pub maximum_publisher_earning_campaigns: u16,
+}
+
+#[derive(Deserialize, Debug, Clone)]
 pub struct Timeouts {
     #[serde(deserialize_with = "seconds_to_std_duration")]
     /// Timeout Duration for the Cache updating all campaigns statuses
@@ -61,29 +70,29 @@ pub struct Timeouts {
 }
 
 #[derive(Debug)]
-pub enum ConfigError {
+pub enum Error {
     Io(std::io::Error),
     Toml(toml::de::Error),
     Environment { actual: String },
 }
 
-impl fmt::Display for ConfigError {
+impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        use ConfigError::*;
+        use Error::*;
 
         match self {
             Io(err) => write!(f, "File reading: {}", err),
             Toml(err) => write!(f, "Toml parsing: {}", err),
             Environment { actual } => write!(
                 f,
-                "Enviroment can only be `development` or `production`, actual: {}",
+                "Environment can only be `development` or `production`, actual: {}",
                 actual
             ),
         }
     }
 }
 
-impl std::error::Error for ConfigError {}
+impl std::error::Error for Error {}
 
 fn seconds_to_std_duration<'de, D>(deserializer: D) -> Result<Duration, D::Error>
 where

--- a/src/config.rs
+++ b/src/config.rs
@@ -7,11 +7,11 @@ use std::time::Duration;
 use url::Url;
 
 lazy_static! {
-    static ref DEVELOPMENT: Config = {
+    pub static ref DEVELOPMENT: Config = {
         toml::from_str(include_str!("../config/dev.toml"))
             .expect("Failed to parse dev.toml config file")
     };
-    static ref PRODUCTION: Config = {
+    pub static ref PRODUCTION: Config = {
         toml::from_str(include_str!("../config/prod.toml"))
             .expect("Failed to parse prod.toml config file")
     };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,7 @@ pub mod config;
 pub mod market;
 pub mod sentry_api;
 pub mod status;
+pub mod util;
 
 use market::MarketApi;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 #![deny(clippy::all)]
 #![deny(rust_2018_idioms)]
-use cache::Cache;
+pub use cache::Cache;
 use hyper::{client::HttpConnector, Body, Client, Method, Request, Response, Server};
 use std::fmt;
 use std::net::SocketAddr;
@@ -9,11 +9,10 @@ use std::sync::Arc;
 use http::{StatusCode, Uri};
 use slog::{error, info, Logger};
 
-mod cache;
+pub mod cache;
 pub mod config;
-mod market;
-mod sentry_api;
-// @TODO: mod status; This is suppressing the warnings
+pub mod market;
+pub mod sentry_api;
 pub mod status;
 
 use market::MarketApi;
@@ -77,7 +76,7 @@ pub async fn serve(
     let client = Client::new();
     let market = Arc::new(MarketApi::new(market_url, logger.clone())?);
 
-    let cache = spawn_fetch_campaigns(market.clone(), logger.clone(), config).await?;
+    let cache = spawn_fetch_campaigns(logger.clone(), config).await?;
 
     // And a MakeService to handle each connection...
     let make_service = make_service_fn(|_| {
@@ -197,16 +196,12 @@ async fn handle(
     }
 }
 
-async fn spawn_fetch_campaigns(
-    market: Arc<MarketApi>,
-    logger: Logger,
-    config: Config,
-) -> Result<Cache, reqwest::Error> {
-    let cache = Cache::initialize(market, logger.clone(), config.clone()).await?;
+async fn spawn_fetch_campaigns(logger: Logger, config: Config) -> Result<Cache, reqwest::Error> {
     info!(
         &logger,
-        "Campaigns have been fetched from the Market & Cache is now initialized..."
+        "Initialize Cache"; "validators" => format_args!("{:?}", &config.validators)
     );
+    let cache = Cache::initialize(logger.clone(), config.clone()).await?;
 
     let cache_spawn = cache.clone();
     // Every few minutes, we will get the non-finalized from the market,
@@ -240,14 +235,13 @@ async fn spawn_fetch_campaigns(
                             "Fetching new Campaigns timed out";
                             "allowed secs" => timeout_duration.as_secs()
                         ),
-                        Ok(Err(e)) => error!(&logger, "{}", e),
-                        _ => info!(&logger, "New Campaigns fetched from Market!"),
+                        _ => info!(&logger, "New Campaigns fetched from Validators!"),
                     }
                 }
                 TimeFor::Update(_) => {
                     let timeout_duration = config.timeouts.cache_update_campaign_statuses;
 
-                    match timeout(timeout_duration, cache_spawn.update_campaigns()).await {
+                    match timeout(timeout_duration, cache_spawn.fetch_campaign_updates()).await {
                         Ok(_) => info!(&logger, "Campaigns statuses updated from Validators!"),
                         Err(_elapsed) => error!(
                                 &logger,

--- a/src/market.rs
+++ b/src/market.rs
@@ -7,11 +7,11 @@ use serde::Deserialize;
 use slog::{info, Logger};
 use std::fmt;
 
-pub(crate) type MarketUrl = String;
+pub type MarketUrl = String;
 pub type Result<T> = std::result::Result<T, Error>;
 
 #[derive(Debug, Clone)]
-pub(crate) struct MarketApi {
+pub struct MarketApi {
     pub market_url: MarketUrl,
     client: Client,
     logger: Logger,
@@ -153,7 +153,7 @@ impl MarketApi {
 
 /// Should we query All or only certain statuses
 #[derive(Debug)]
-pub(crate) enum Statuses<'a> {
+pub enum Statuses<'a> {
     All,
     Only(&'a [StatusType]),
 }

--- a/src/sentry_api.rs
+++ b/src/sentry_api.rs
@@ -46,11 +46,12 @@ impl SentryApi {
         validator: &Url,
         page: u64,
     ) -> Result<ChannelListResponse, reqwest::Error> {
+        // @TODO: Use `ChannelListQuery` when it's moved to `primitives` (see https://github.com/AdExNetwork/adex-validator-stack-rust/issues/303)
         let url = format!(
             "{}/channel/list?page={}&validUntil={}",
             validator,
             page,
-            Utc::now()
+            Utc::now().timestamp()
         );
 
         self.client

--- a/src/sentry_api.rs
+++ b/src/sentry_api.rs
@@ -1,9 +1,14 @@
+use chrono::Utc;
+use futures::future::{try_join_all, TryFutureExt};
 use primitives::{
-    sentry::{LastApprovedResponse, ValidatorMessage, ValidatorMessageResponse},
-    ValidatorDesc,
+    sentry::{
+        ChannelListResponse, LastApprovedResponse, ValidatorMessage, ValidatorMessageResponse,
+    },
+    Channel, ValidatorDesc,
 };
-use reqwest::{Client, Error};
+use reqwest::{Client, Error, Response};
 use std::time::Duration;
+use url::Url;
 
 #[derive(Debug, Clone)]
 pub struct SentryApi {
@@ -16,6 +21,43 @@ impl SentryApi {
         let client = Client::builder().timeout(request_timeout).build()?;
 
         Ok(Self { client })
+    }
+
+    pub async fn get_validator_channels(&self, validator: &Url) -> Result<Vec<Channel>, Error> {
+        let first_page = self.fetch_page(&validator, 0).await?;
+
+        if first_page.total_pages < 2 {
+            Ok(first_page.channels)
+        } else {
+            let all: Vec<ChannelListResponse> =
+                try_join_all((1..first_page.total_pages).map(|i| self.fetch_page(&validator, i)))
+                    .await?;
+
+            let result_all: Vec<Channel> = std::iter::once(first_page)
+                .chain(all.into_iter())
+                .flat_map(|ch| ch.channels.into_iter())
+                .collect();
+            Ok(result_all)
+        }
+    }
+
+    async fn fetch_page(
+        &self,
+        validator: &Url,
+        page: u64,
+    ) -> Result<ChannelListResponse, reqwest::Error> {
+        let url = format!(
+            "{}/channel/list?page={}&validUntil={}",
+            validator,
+            page,
+            Utc::now()
+        );
+
+        self.client
+            .get(&url)
+            .send()
+            .and_then(|res: Response| res.json::<ChannelListResponse>())
+            .await
     }
 
     pub async fn get_last_approved(

--- a/src/status.rs
+++ b/src/status.rs
@@ -9,7 +9,7 @@ use reqwest::Error;
 
 #[cfg(test)]
 #[path = "status_test.rs"]
-mod test;
+pub mod test;
 
 #[derive(Debug, Eq, PartialEq, Clone)]
 pub enum Status {
@@ -128,11 +128,7 @@ impl Messages {
     }
 
     fn has_leader_new_state(&self) -> bool {
-        self.leader
-            .last_approved
-            .as_ref()
-            .map(|last_approved| last_approved.new_state.is_some())
-            .unwrap_or(false)
+        self.get_leader_new_state().is_some()
     }
 
     /// `from`: If `None` it will just check for a recent Heartbeat

--- a/src/status.rs
+++ b/src/status.rs
@@ -1,7 +1,6 @@
 use crate::sentry_api::SentryApi;
 use chrono::{DateTime, Duration, Utc};
 use primitives::{
-    market::Status as MarketStatus,
     sentry::{HeartbeatValidatorMessage, LastApprovedResponse, NewStateValidatorMessage},
     validator::{ApproveState, MessageTypes},
     BalancesMap, BigNum, Channel, ValidatorId,
@@ -12,14 +11,14 @@ use reqwest::Error;
 #[path = "status_test.rs"]
 mod test;
 
-#[derive(Debug)]
+#[derive(Debug, Eq, PartialEq, Clone)]
 pub enum Status {
     // Active and Ready
     Active,
     Pending,
     Initializing,
     Waiting,
-    Finalized(Finalized, BalancesMap),
+    Finalized(Finalized),
     Unsound {
         disconnected: bool,
         offline: bool,
@@ -28,46 +27,7 @@ pub enum Status {
     },
 }
 
-impl From<&MarketStatus> for Status {
-    fn from(market_status: &MarketStatus) -> Self {
-        use primitives::market::StatusType::*;
-        match market_status.status_type {
-            Active | Ready => Self::Active,
-            Pending => Self::Pending,
-            Initializing => Self::Initializing,
-            Waiting => Self::Waiting,
-            Offline => Self::Unsound {
-                disconnected: false,
-                offline: true,
-                rejected_state: false,
-                unhealthy: false,
-            },
-            Disconnected => Self::Unsound {
-                disconnected: true,
-                offline: false,
-                rejected_state: false,
-                unhealthy: false,
-            },
-            Unhealthy => Self::Unsound {
-                disconnected: false,
-                offline: false,
-                rejected_state: false,
-                unhealthy: true,
-            },
-            Invalid => Self::Unsound {
-                disconnected: false,
-                offline: false,
-                rejected_state: true,
-                unhealthy: false,
-            },
-            Expired => Self::Finalized(Finalized::Expired, market_status.balances.clone()),
-            Exhausted => Self::Finalized(Finalized::Exhausted, market_status.balances.clone()),
-            Withdraw => Self::Finalized(Finalized::Withdraw, market_status.balances.clone()),
-        }
-    }
-}
-
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub enum Finalized {
     Expired,
     Exhausted,
@@ -86,6 +46,18 @@ impl Messages {
             .last_approved
             .as_ref()
             .and_then(|last_approved| last_approved.new_state.as_ref())
+    }
+
+    fn get_leader_new_state_balances(&self) -> BalancesMap {
+        self.leader
+            .last_approved
+            .as_ref()
+            .and_then(|last_approved| last_approved.new_state.as_ref())
+            .and_then(|new_state| match &new_state.msg {
+                MessageTypes::NewState(new_state) => Some(new_state.balances.clone()),
+                _ => None,
+            })
+            .unwrap_or_default()
     }
 
     fn get_follower_approve_state_msg(&self) -> Option<&ApproveState> {
@@ -263,10 +235,13 @@ pub async fn is_finalized(sentry: &SentryApi, channel: &Channel) -> Result<IsFin
     })
 }
 
-pub async fn get_status(sentry: &SentryApi, channel: &Channel) -> Result<Status, Error> {
+pub async fn get_status(
+    sentry: &SentryApi,
+    channel: &Channel,
+) -> Result<(Status, BalancesMap), Error> {
     // continue only if Campaign is not Finalized
     let leader_la = match is_finalized(sentry, channel).await? {
-        IsFinalized::Yes { reason, balances } => return Ok(Status::Finalized(reason, balances)),
+        IsFinalized::Yes { reason, balances } => return Ok((Status::Finalized(reason), balances)),
         IsFinalized::No { leader } => leader,
     };
 
@@ -282,7 +257,10 @@ pub async fn get_status(sentry: &SentryApi, channel: &Channel) -> Result<Status,
 
     // impl: isInitializing
     if is_initializing(&messages) {
-        return Ok(Status::Initializing);
+        return Ok((
+            Status::Initializing,
+            messages.get_leader_new_state_balances(),
+        ));
     }
 
     // impl: isOffline
@@ -298,19 +276,20 @@ pub async fn get_status(sentry: &SentryApi, channel: &Channel) -> Result<Status,
     let unhealthy = is_unhealthy(&messages);
 
     if disconnected || offline || rejected_state || unhealthy {
-        return Ok(Status::Unsound {
+        let status = Status::Unsound {
             disconnected,
             offline,
             rejected_state,
             unhealthy,
-        });
+        };
+        return Ok((status, messages.get_leader_new_state_balances()));
     }
 
     // isActive & isReady (we don't need distinguish between Active & Ready here)
     if is_active(&messages) && is_ready(&messages) {
-        Ok(Status::Active)
+        Ok((Status::Active, messages.get_leader_new_state_balances()))
     } else {
-        Ok(Status::Waiting)
+        Ok((Status::Waiting, messages.get_leader_new_state_balances()))
     }
 }
 

--- a/src/status_test.rs
+++ b/src/status_test.rs
@@ -31,7 +31,7 @@ fn get_request_channel(server: &MockServer) -> Channel {
     channel
 }
 
-fn get_heartbeat_msg(recency: Duration, from: ValidatorId) -> HeartbeatValidatorMessage {
+pub(crate) fn get_heartbeat_msg(recency: Duration, from: ValidatorId) -> HeartbeatValidatorMessage {
     HeartbeatValidatorMessage {
         from,
         received: Utc::now() - recency,
@@ -43,9 +43,9 @@ fn get_heartbeat_msg(recency: Duration, from: ValidatorId) -> HeartbeatValidator
     }
 }
 
-fn get_approve_state_msg(is_healthy: bool) -> ApproveStateValidatorMessage {
+pub(crate) fn get_approve_state_msg(is_healthy: bool) -> ApproveStateValidatorMessage {
     ApproveStateValidatorMessage {
-        from: DUMMY_VALIDATOR_LEADER.id,
+        from: DUMMY_VALIDATOR_FOLLOWER.id,
         received: Utc::now(),
         msg: MessageTypes::ApproveState(ApproveState {
             state_root: String::from("0x0"),
@@ -55,7 +55,7 @@ fn get_approve_state_msg(is_healthy: bool) -> ApproveStateValidatorMessage {
     }
 }
 
-fn get_new_state_msg() -> NewStateValidatorMessage {
+pub(crate) fn get_new_state_msg() -> NewStateValidatorMessage {
     NewStateValidatorMessage {
         from: DUMMY_VALIDATOR_LEADER.id,
         received: Utc::now(),
@@ -67,7 +67,7 @@ fn get_new_state_msg() -> NewStateValidatorMessage {
     }
 }
 
-fn get_new_state_validator_msg() -> ValidatorMessage {
+pub(crate) fn get_new_state_validator_msg() -> ValidatorMessage {
     ValidatorMessage {
         from: DUMMY_VALIDATOR_LEADER.id,
         received: Utc::now(),

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,0 +1,14 @@
+#[cfg(test)]
+pub mod test {
+    use slog::Logger;
+
+    pub fn discard_logger() -> Logger {
+        use slog::{o, Discard, Drain};
+        use slog_async::Async;
+
+        let drain = Discard.fuse();
+        let drain = Async::new(drain).build().fuse();
+
+        Logger::root(drain, o!())
+    }
+}


### PR DESCRIPTION
See #23 for more details.
### Resolves:
1. [x] Configuration list of validators to fetch the campaigns from (instead of the market)
2. [x] Fetch the active (channel.valid_until > Now) campaigns (and compute their status)
